### PR TITLE
WP-18:better backwards compability

### DIFF
--- a/admin/class-bigbluebutton-admin.php
+++ b/admin/class-bigbluebutton-admin.php
@@ -185,7 +185,12 @@ class Bigbluebutton_Admin {
 				echo '<a href="' . esc_url( $permalink ) . '" target="_blank">' . esc_url( $permalink ) . '</a>';
 				break;
 			case 'token':
-				echo 'meeting' . esc_attr( $post_id );
+				if ( metadata_exists( 'post', $post_id, 'bbb-room-token' ) ) {
+					$token = get_post_meta( $post_id, 'bbb-room-token', true );
+				} else {
+					$token = 'z' . esc_attr( $post_id );
+				}
+				echo esc_attr( $token );
 				break;
 			case 'moderator-code':
 				echo esc_attr( get_post_meta( $post_id, 'bbb-room-moderator-code', true ) );

--- a/includes/class-bigbluebutton-migration.php
+++ b/includes/class-bigbluebutton-migration.php
@@ -121,6 +121,7 @@ class Bigbluebutton_Migration {
 					$meeting_id = ( 12 == strlen( $old_room->meetingID ) ) ? sha1( home_url() . $old_room->meetingID ) : $old_room->meetingID;
 					update_post_meta( $new_room_id, 'bbb-room-moderator-code', $old_room->moderatorPW );
 					update_post_meta( $new_room_id, 'bbb-room-viewer-code', $old_room->attendeePW );
+					update_post_meta( $new_room_id, 'bbb-room-token', $old_room->meetingID );
 					update_post_meta( $new_room_id, 'bbb-room-meeting-id', $meeting_id );
 					if ( $old_room_logs_table_exists ) {
 						$wpdb->delete( $old_room_logs_table, array( 'meetingID' => $meeting_id ) );

--- a/public/class-bigbluebutton-public-shortcode.php
+++ b/public/class-bigbluebutton-public-shortcode.php
@@ -45,29 +45,18 @@ class Bigbluebutton_Public_Shortcode {
 		$type           = 'room';
 		$author         = (int) get_the_author_meta( 'ID' );
 		$display_helper = new Bigbluebutton_Display_Helper( plugin_dir_path( __FILE__ ) );
-		$tokens_string  = '';
 		$list_tokens    = false;
 
 		if ( 'edit.php' == $pagenow || 'post.php' == $pagenow || 'post-new.php' == $pagenow ) {
 			return $content;
 		}
 
-		foreach ( $atts as $key => $param ) {
-			if ( 'type' == $key && 'recording' == $param ) {
-				$type = 'recording';
-			} elseif ( 'token' == $key ) {
-				if ( 'token' == substr( $param, 0, 5 ) ) {
-					$param = substr( $param, 5 );
-				}
-				$tokens_string = $param;
-				$list_tokens = true;
-			} elseif ( $list_tokens ) {
-				if ( 'token' == substr( $param, 0, 5 ) ) {
-					$param = substr( $param, 5 );
-				}
-				$tokens_string .= ',' . $param;
-			}
+		if ( array_key_exists( 'type', $atts ) && 'recording' == $atts['type'] ) {
+			$type = 'recording';
+			unset( $atts['type'] );
 		}
+
+		$tokens_string = Bigbluebutton_Tokens_Helper::get_token_string_from_atts( $atts );
 
 		if ( 'room' == $type ) {
 			$content .= Bigbluebutton_Tokens_Helper::join_form_from_tokens_string( $display_helper, $tokens_string, $author );

--- a/public/class-bigbluebutton-public-shortcode.php
+++ b/public/class-bigbluebutton-public-shortcode.php
@@ -45,9 +45,8 @@ class Bigbluebutton_Public_Shortcode {
 		$type           = 'room';
 		$author         = (int) get_the_author_meta( 'ID' );
 		$display_helper = new Bigbluebutton_Display_Helper( plugin_dir_path( __FILE__ ) );
-		$list_tokens    = false;
 
-		if ( 'edit.php' == $pagenow || 'post.php' == $pagenow || 'post-new.php' == $pagenow ) {
+		if ( ! Bigbluebutton_Tokens_Helper::can_display_room_on_page() ) {
 			return $content;
 		}
 

--- a/public/class-bigbluebutton-public-shortcode.php
+++ b/public/class-bigbluebutton-public-shortcode.php
@@ -21,12 +21,13 @@
 class Bigbluebutton_Public_Shortcode {
 
 	/**
-	 * Register bigbluebutton shortcode.
+	 * Register bigbluebutton shortcodes.
 	 *
 	 * @since   3.0.0
 	 */
 	public function register_shortcodes() {
 		add_shortcode( 'bigbluebutton', array( $this, 'display_bigbluebutton_shortcode' ) );
+		add_shortcode( 'bigbluebutton_recordings', array( $this, 'display_bigbluebutton_old_recordings_shortcode' ) );
 	}
 
 	/**
@@ -45,15 +46,27 @@ class Bigbluebutton_Public_Shortcode {
 		$author         = (int) get_the_author_meta( 'ID' );
 		$display_helper = new Bigbluebutton_Display_Helper( plugin_dir_path( __FILE__ ) );
 		$tokens_string  = '';
+		$list_tokens    = false;
 
 		if ( 'edit.php' == $pagenow || 'post.php' == $pagenow || 'post-new.php' == $pagenow ) {
 			return $content;
 		}
-		if ( array_key_exists( 'type', $atts ) && 'recording' == $atts['type'] ) {
-			$type = 'recording';
-		}
-		if ( array_key_exists( 'token', $atts ) ) {
-			$tokens_string = $atts['token'];
+
+		foreach ( $atts as $key => $param ) {
+			if ( 'type' == $key && 'recording' == $param ) {
+				$type = 'recording';
+			} elseif ( 'token' == $key ) {
+				if ( 'token' == substr( $param, 0, 5 ) ) {
+					$param = substr( $param, 5 );
+				}
+				$tokens_string = $param;
+				$list_tokens = true;
+			} elseif ( $list_tokens ) {
+				if ( 'token' == substr( $param, 0, 5 ) ) {
+					$param = substr( $param, 5 );
+				}
+				$tokens_string .= ',' . $param;
+			}
 		}
 
 		if ( 'room' == $type ) {
@@ -62,5 +75,19 @@ class Bigbluebutton_Public_Shortcode {
 			$content .= Bigbluebutton_Tokens_Helper::recordings_table_from_tokens_string( $display_helper, $tokens_string, $author );
 		}
 		return $content;
+	}
+
+	/**
+	 * Shows recordings for the old recordings shortcode format.
+	 *
+	 * @since   3.0.0
+	 * @param   Array  $atts       Parameters in the shortcode.
+	 * @param   String $content    Content of the shortcode.
+	 *
+	 * @return  String $content    Content of the shortcode with recordings.
+	 */
+	public function display_bigbluebutton_old_recordings_shortcode( $atts = [], $content = null ) {
+		$atts['type'] = 'recording';
+		return $this->display_bigbluebutton_shortcode( $atts, $content );
 	}
 }

--- a/public/class-bigbluebutton-public.php
+++ b/public/class-bigbluebutton-public.php
@@ -167,7 +167,7 @@ class Bigbluebutton_Public {
 			return $content;
 		}
 
-		$token    = 'meeting' . $room_id;
+		$token    = 'z' . $room_id;
 		$content .= '[bigbluebutton token="' . $token . '"]';
 
 		// Add recordings list to post content if the room is recordable.

--- a/public/class-bigbluebutton-public.php
+++ b/public/class-bigbluebutton-public.php
@@ -156,7 +156,7 @@ class Bigbluebutton_Public {
 	public function bbb_room_content( $content ) {
 		global $pagenow;
 
-		if ( 'edit.php' == $pagenow || 'post.php' == $pagenow || 'post-new.php' == $pagenow ) {
+		if ( ! Bigbluebutton_Tokens_Helper::can_display_room_on_page() ) {
 			return $content;
 		}
 

--- a/public/helpers/class-bigbluebutton-tokens-helper.php
+++ b/public/helpers/class-bigbluebutton-tokens-helper.php
@@ -28,6 +28,32 @@ class Bigbluebutton_Tokens_Helper {
 	private static $error_message;
 
 	/**
+	 * Get tokens string from shortcode attributes.
+	 *
+	 * @since   3.0.0
+	 * @param   Array $atts              Array of attributes submitted in the shortcode.
+	 * @return  String $tokens_string    List of tokens separated by commas.
+	 */
+	public static function get_token_string_from_atts( $atts ) {
+		$tokens_string = '';
+
+		foreach ( $atts as $key => $param ) {
+			if ( 'token' == $key ) {
+				if ( 'token' == substr( $param, 0, 5 ) ) {
+					$param = substr( $param, 5 );
+				}
+				$tokens_string .= $param;
+			} else {
+				if ( 'token' == substr( $param, 0, 5 ) ) {
+					$param = substr( $param, 5 );
+				}
+				$tokens_string .= ',' . $param;
+			}
+		}
+		return $tokens_string;
+	}
+
+	/**
 	 * Get join form as an HTML string.
 	 *
 	 * @since   3.0.0
@@ -170,7 +196,7 @@ class Bigbluebutton_Tokens_Helper {
 	 *
 	 * @since   3.0.0
 	 *
-	 * @param	String $token     String value of the token.
+	 * @param   String $token     String value of the token.
 	 * @return  Integer $room_id  Room ID associated with the token.
 	 */
 	private static function check_if_room_exists_for_new_token_format( $token ) {
@@ -210,7 +236,7 @@ class Bigbluebutton_Tokens_Helper {
 		);
 
 		$query = new WP_Query( $args );
-		if ( $query->posts ) {
+		if ( ! empty( $query->posts ) ) {
 			foreach ( $query->posts as $key => $room_id ) {
 				$room = get_post( $room_id );
 				if ( 'publish' != $room->post_status ) {

--- a/public/helpers/class-bigbluebutton-tokens-helper.php
+++ b/public/helpers/class-bigbluebutton-tokens-helper.php
@@ -192,6 +192,21 @@ class Bigbluebutton_Tokens_Helper {
 	}
 
 	/**
+	 * Check if rooms and recordings should load on this page.
+	 *
+	 * @since  3.0.0
+	 * @return Boolean  $can_view          Boolean value of whether join room form and recordings should show on this page.
+	 */
+	public static function can_display_room_on_page() {
+		global $pagenow;
+		$can_view = true;
+		if ( 'edit.php' == $pagenow || 'post.php' == $pagenow || 'post-new.php' == $pagenow ) {
+			$can_view = false;
+		}
+		return $can_view;
+	}
+
+	/**
 	 * Get room ID using new token format.
 	 *
 	 * @since   3.0.0


### PR DESCRIPTION
Allow users to use old tokens or new tokens. Migrated tokens are stored and not changed.
Allow users to use old shortcode for recordings and token list format.