### PR TITLE
closes #67 GH-67/change plugin permission capability to access rooms

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -75,9 +75,9 @@ For anonymous users the Name will be always required, but again the Password req
 
 You should install and activate the "Members" plugin by Justin Tadlock and in the Dasboard under the "Users" > "Roles", update the permissions.
 
-To allow another user to create and edit rooms, assign them a role which has the permissions, edit_plugins and edit_bbb_rooms, publish_bbb_rooms, delete_bbb_rooms, delete_published_bbb_rooms, and edit_published_bbb_rooms. The permission structure is similar for posts and pages.
+To allow another user to create and edit rooms, assign them a role which has the permissions, activate_plugins and edit_bbb_rooms, publish_bbb_rooms, delete_bbb_rooms, delete_published_bbb_rooms, and edit_published_bbb_rooms. The permission structure is similar for posts and pages.
 
-To allow another user to create and edit room categories, assign them a role which has the permissions, edit_plugins and manage_categories. This does not give them permission to create rooms. They can only manage room categories.
+To allow another user to create and edit room categories, assign them a role which has the permissions, activate_plugins and manage_categories. This does not give them permission to create rooms. They can only manage room categories.
 
 To allow another user to join as moderator, viewer, or with a code, assign them to a role with one of the corresponding permissions, join_as_moderator_bbb_room, join_as_viewer_bbb_room, or join_with_password_bbb_room. By default, the owner of the room will always join their rooms as a moderator. The default does not apply to others' rooms.
 

--- a/admin/class-bigbluebutton-admin.php
+++ b/admin/class-bigbluebutton-admin.php
@@ -109,19 +109,19 @@ class Bigbluebutton_Admin {
 	 */
 	public function create_admin_menu() {
 		add_menu_page(
-			__( 'Rooms', 'bigbluebutton' ), __( 'Rooms', 'bigbluebutton' ), 'edit_plugins', 'bbb_room',
+			__( 'Rooms', 'bigbluebutton' ), __( 'Rooms', 'bigbluebutton' ), 'activate_plugins', 'bbb_room',
 			'', 'dashicons-video-alt2'
 		);
 
 		if ( current_user_can( 'manage_categories' ) ) {
 			add_submenu_page(
-				'bbb_room', __( 'Rooms', 'bigbluebutton' ), __( 'Categories' ), 'edit_plugins',
+				'bbb_room', __( 'Rooms', 'bigbluebutton' ), __( 'Categories' ), 'activate_plugins',
 				'edit-tags.php?taxonomy=bbb-room-category', ''
 			);
 		}
 
 		add_submenu_page(
-			'bbb_room', __( 'Rooms', 'bigbluebutton' ), __( 'Settings' ), 'edit_plugins',
+			'bbb_room', __( 'Rooms', 'bigbluebutton' ), __( 'Settings' ), 'activate_plugins',
 			'bbb-room-server-settings', array( $this, 'display_room_server_settings' )
 		);
 	}

--- a/includes/class-bigbluebutton-activator.php
+++ b/includes/class-bigbluebutton-activator.php
@@ -84,7 +84,7 @@ class Bigbluebutton_Activator {
 		$set_join_cap = self::join_permissions_set( $role );
 		$role->add_cap( 'read_bbb_room' );
 
-		if ( $role->has_cap( 'edit_plugins' ) ) {
+		if ( $role->has_cap( 'activate_plugins' ) ) {
 			self::set_admin_capability( $role );
 		}
 


### PR DESCRIPTION
Edit Plugins is by default blocked by iThemes Security in the Disable File Editor option.
Change capability so users require activate_plugins instead of edit_plugins to go to rooms in the administrator dashboard.