### PR TITLE
Increase response timeout while testing URL

### DIFF
--- a/includes/class-bigbluebutton-api.php
+++ b/includes/class-bigbluebutton-api.php
@@ -362,7 +362,7 @@ class Bigbluebutton_Api {
 	 * @return  Array|WP_Error  $response   Server response in array format.
 	 */
 	private static function get_response( $url ) {
-		$result = wp_remote_get( esc_url_raw( $url ) );
+		$result = wp_remote_get( esc_url_raw( $url ) , array( 'timeout' => 180 ));
 		return $result;
 	}
 


### PR DESCRIPTION
The normal timeout might be sufficient for a BBB-server with zero or only a few meetings. But for example a scalelite-server, having hundreds of meetings at the time of testing, does respond not fast enough. An increasing of the timeout solves the problem.